### PR TITLE
Add editable CLI-style header

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -91,3 +91,24 @@
   cursor: pointer;
 }
 
+/* CLI prompt styling */
+#cli-prompt {
+  outline: none;
+  font-family: 'Courier New', Courier, monospace;
+  letter-spacing: 0.05em;
+  cursor: text;
+  caret-color: transparent; /* Hide the browser's caret */
+}
+
+#cli-prompt:focus {
+  outline: none;
+  caret-color: transparent; /* Ensure caret stays hidden when focused */
+}
+
+/* Terminal-style cursor */
+#cli-cursor {
+  margin-left: 2px;
+  vertical-align: baseline;
+  display: inline-block;
+}
+

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -41,3 +41,56 @@ liveSocket.connect()
 // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
 // >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket
+
+// CLI-like editable header functionality
+document.addEventListener("DOMContentLoaded", () => {
+  const cliPrompt = document.getElementById("cli-prompt");
+  const cliCursor = document.getElementById("cli-cursor");
+  const header = document.querySelector("header");
+  
+  if (cliPrompt && cliCursor) {
+    // Focus on page load
+    cliPrompt.focus();
+    // Move cursor to end of text
+    const range = document.createRange();
+    const sel = window.getSelection();
+    range.selectNodeContents(cliPrompt);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+    
+    // Focus the text editor when clicking anywhere in the header
+    if (header) {
+      header.addEventListener("click", (e) => {
+        // Don't focus if clicking on links or other interactive elements
+        if (e.target.closest("a") && e.target !== cliPrompt) return;
+        cliPrompt.focus();
+        // Move cursor to end of text
+        const range = document.createRange();
+        const sel = window.getSelection();
+        range.selectNodeContents(cliPrompt);
+        range.collapse(false);
+        sel.removeAllRanges();
+        sel.addRange(range);
+      });
+    }
+    
+    // Keep our custom cursor visible at all times
+    // The browser's caret is hidden via CSS
+    
+    // Prevent line breaks
+    cliPrompt.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        cliPrompt.blur();
+      }
+    });
+    
+    // Keep text plain when pasting
+    cliPrompt.addEventListener("paste", (e) => {
+      e.preventDefault();
+      const text = (e.clipboardData || window.clipboardData).getData("text");
+      document.execCommand("insertText", false, text);
+    });
+  }
+});

--- a/lib/blog_web/templates/layout/root.html.heex
+++ b/lib/blog_web/templates/layout/root.html.heex
@@ -16,8 +16,7 @@
       <div class="max-w-7xl py-16 px-4 sm:py-16 sm:px-6 lg:px-8 lg:flex lg:justify-between">
         <div class="max-w-xl">
           <h2 class="text-4xl font-extrabold text-white sm:text-5xl sm:tracking-tight lg:text-5xl">
-            <a class="typing" href="/">Hello world</a>
-            <div class="inline-block bg-white w-5 h-9 animate-blink"></div>
+            <span class="typing" contenteditable="true" spellcheck="false" id="cli-prompt">Hello world</span><span class="inline-block bg-white w-3.5 h-8 animate-blink" id="cli-cursor"></span>
           </h2>
           <p class="mt-5 text-xl text-gray-400">I'm Vincent Raerek</p>
         </div>


### PR DESCRIPTION
## Summary
- Made the "Hello world" header text editable with a terminal-like user experience
- Added custom blinking block cursor that replaces the browser's default caret
- Implemented click-to-focus functionality across the entire header area

## Test plan
- [x] Visit the homepage and verify the header text is automatically focused
- [x] Click on the "Hello world" text and edit it
- [x] Verify the blinking block cursor appears and the browser's default cursor is hidden
- [x] Test that pressing Enter blurs the field instead of creating line breaks
- [x] Test pasting formatted text to ensure it's converted to plain text
- [x] Click anywhere in the header area to verify it focuses the text editor
- [x] Verify the cursor alignment and width look appropriate

🤖 Generated with [Claude Code](https://claude.ai/code)